### PR TITLE
Add backup command

### DIFF
--- a/cli/commands/backup.py
+++ b/cli/commands/backup.py
@@ -1,5 +1,6 @@
 import typer
 import boto3
+import time
 from typing import Annotated, Dict, Any
 from datetime import datetime
 
@@ -8,11 +9,14 @@ from cli.internal.aws.session import create_session
 from cli.internal.aws.client import get_client
 from cli.internal.aws.resource_filtering import list_resource_by_tag
 
+POLL_INTERVAL = 30 #seconds
+
 app = typer.Typer()
 
 @app.command()
 def backup(
-    file_path: Annotated[str, typer.Option("-c", "--config", help="Config file used for defining resources")]
+    file_path: Annotated[str, typer.Option("-c", "--config", help="Config file used for defining resources")],
+    parallel: Annotated[int, typer.Option("-p", "--parallel", help="Number of backups to run in parallel")] = 3
 ):
     config = read_config(file_path)
     provider = config["provider"]["name"]
@@ -31,15 +35,49 @@ def backup(
             
             resources = list_resource_by_tag(client, service, tags)
             
-            for resource in resources:
-                if resource["Engine"].startswith("aurora"):
-                    resource_type = "rds"
+            available_clusters = [
+                resource for resource in resources if resource["Status"] == "available"
+            ]
+            
+            resource_type = ""
+            if available_clusters and available_clusters[0]["Engine"].startswith("aurora"):
+                resource_type = "rds"
                     
-                match resource_type:
-                    case "rds":
-                        if resource["Status"] == "available":
-                            result = initiate_snapshot(resource, session, region)
-                            typer.echo(f"Result: {result}")
+            match resource_type:
+                case "rds":    
+                    in_progress = []
+                    pending = list(available_clusters)
+                    
+                    while pending or in_progress:
+                        while len(in_progress) < parallel and pending:
+                            resource = pending.pop(0)
+                            snapshot_result = initiate_snapshot(resource, session, region)
+                            in_progress.append({
+                                'cluster': resource['DBClusterIdentifier'],
+                                'snapshot_id': snapshot_result['DBClusterSnapshotIdentifier'],
+                                'snapshot_arn': snapshot_result['DBClusterSnapshotArn'],
+                                'started': time.time()
+                            })
+                            typer.echo(f"Started backup: {snapshot_result['DBClusterSnapshotIdentifier']}")
+                            
+                        # Poll for completion
+                        if in_progress:
+                            time.sleep(POLL_INTERVAL)
+                            
+                            completed = []
+                            for backup in in_progress:
+                                status = check_snapshot_status(backup['snapshot_id'], session, region)
+                                if status in ["available", "failed"]:
+                                    duration = time.time() - backup['started']
+                                    typer.echo(f"Backup {backup['snapshot_id']}: {status} (took {duration:.0f}s)")
+                                    completed.append(backup)
+                                    
+                            for backup in completed:
+                                in_progress.remove(backup)
+                                
+                case _:
+                    typer.echo(f"Resource type {resource_type} is not supported yet.")
+                    raise typer.Exit(code=1)
         case _:
             typer.echo(f"Provider {provider} is not supported yet.")
             raise typer.Exit(code=1)
@@ -66,6 +104,14 @@ def initiate_snapshot(resource: dict[str, any], session: boto3.Session, region: 
             'error': str(e)
         })
         typer.echo(f"Failed to create snapshot for cluster {resource_id}: {str(e)}")
+
+def check_snapshot_status(snapshot_id: str, session: boto3.Session, region: str) -> str:
+    """Check the current status of a snapshot."""
+    client = get_client("rds", session, region)
+    response = client.describe_db_cluster_snapshots(
+        DBClusterSnapshotIdentifier=snapshot_id
+    )
+    return response['DBClusterSnapshots'][0]['Status']
 
 def create_cluster_snapshot(cluster_id: str, prefix: str, session: boto3.Session, region: str) -> Dict[str, Any]:
     timestamp = datetime.now().strftime('%Y-%m-%d-%H-%M-%S')

--- a/cli/commands/backup.py
+++ b/cli/commands/backup.py
@@ -1,8 +1,99 @@
 import typer
-from typing import Annotated
+import boto3
+from typing import Annotated, Dict, Any
+from datetime import datetime
+
+from cli.internal.utility.config import read_config
+from cli.internal.aws.session import create_session
+from cli.internal.aws.client import get_client
+from cli.internal.aws.resource_filtering import list_resource_by_tag
 
 app = typer.Typer()
 
 @app.command()
-def backup():
-    print("Hello from backup command!")
+def backup(
+    file_path: Annotated[str, typer.Option("-c", "--config", help="Config file used for defining resources")]
+):
+    config = read_config(file_path)
+    provider = config["provider"]["name"]
+    
+    auth = config["auth"]
+    session = create_session(auth)
+    
+    match provider:
+        case "aws":
+            service = config["protect"]["resources"][0]["type"]
+            region = config["provider"]["region"]
+            tags = config["protect"]["resources"][0]["discover"]
+            resource_type = ""
+            
+            client = get_client(service, session, region)
+            
+            resources = list_resource_by_tag(client, service, tags)
+            
+            for resource in resources:
+                if resource["Engine"].startswith("aurora"):
+                    resource_type = "rds"
+                    
+                match resource_type:
+                    case "rds":
+                        result = initiate_snapshot(resource, session, region)
+                        return result
+        case _:
+            typer.echo(f"Provider {provider} is not supported yet.")
+            raise typer.Exit(code=1)
+
+def initiate_snapshot(resource: dict[str, any], session: boto3.Session, region: None = "us-east-1") -> str:
+    snapshot_results = []
+    resource_id = resource['DBClusterIdentifier']
+    prefix = "backup"
+                        
+    try:
+        snapshot_result = create_cluster_snapshot(resource_id, prefix, session, region)
+        snapshot_results.append({
+            "cluster_id": resource_id,
+            "snapshot_id": snapshot_result["DBClusterSnapshotIdentifier"],
+            "status": "initiated",
+            "snapshot_arn": snapshot_result["DBClusterSnapshotArn"]
+        })
+                            
+        typer.echo(f"Successfully initiated snapshot for cluster: {resource_id}")
+    except Exception as e:
+        snapshot_results.append({
+            'cluster_id': resource_id,
+            'status': 'failed',
+            'error': str(e)
+        })
+        typer.echo(f"Failed to create snapshot for cluster {resource_id}: {str(e)}")
+
+def create_cluster_snapshot(cluster_id: str, prefix: str, session: boto3.Session, region: str) -> Dict[str, Any]:
+    timestamp = datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
+    snapshot_id = f"{prefix}-{cluster_id}-{timestamp}"
+    
+    try:
+        client = get_client("rds", session, region)
+        
+        response = client.create_db_cluster_snapshot(
+            DBClusterSnapshotIdentifier=snapshot_id,
+            DBClusterIdentifier=cluster_id,
+            Tags=[
+                {
+                    'Key': 'CreatedBy',
+                    'Value': 'snapctl'
+                },
+                {
+                    'Key': 'CreatedAt',
+                    'Value': timestamp
+                },
+                {
+                    'Key': 'Prefix',
+                    'Value': prefix
+                }
+            ]
+        )
+        
+        return response['DBClusterSnapshot']
+        
+    except Exception as e:
+        typer.echo(f"Error creating snapshot for {cluster_id}: {str(e)}")
+        raise

--- a/cli/commands/backup.py
+++ b/cli/commands/backup.py
@@ -37,8 +37,9 @@ def backup(
                     
                 match resource_type:
                     case "rds":
-                        result = initiate_snapshot(resource, session, region)
-                        typer.echo(f"Result: {result}")
+                        if resource["Status"] == "available":
+                            result = initiate_snapshot(resource, session, region)
+                            typer.echo(f"Result: {result}")
         case _:
             typer.echo(f"Provider {provider} is not supported yet.")
             raise typer.Exit(code=1)

--- a/cli/commands/backup.py
+++ b/cli/commands/backup.py
@@ -78,16 +78,24 @@ def create_cluster_snapshot(cluster_id: str, prefix: str, session: boto3.Session
             DBClusterIdentifier=cluster_id,
             Tags=[
                 {
-                    'Key': 'CreatedBy',
-                    'Value': 'snapctl'
+                    "Key": "resource",
+                    "Value": f"{cluster_id}"
                 },
                 {
-                    'Key': 'CreatedAt',
-                    'Value': timestamp
+                    "Key": "createdAt",
+                    "Value": timestamp
                 },
                 {
-                    'Key': 'Prefix',
-                    'Value': prefix
+                    "Key": "prefix",
+                    "Value": prefix
+                },
+                {
+                    "Key": "version",
+                    "Value": "0.1.0"
+                },
+                {
+                    "Key": "origin",
+                    "Value": "snapctl"
                 }
             ]
         )

--- a/cli/commands/backup.py
+++ b/cli/commands/backup.py
@@ -1,0 +1,8 @@
+import typer
+from typing import Annotated
+
+app = typer.Typer()
+
+@app.command()
+def backup():
+    print("Hello from backup command!")

--- a/cli/commands/backup.py
+++ b/cli/commands/backup.py
@@ -1,9 +1,5 @@
-import resource
 import typer
-import boto3
-import time
-from typing import Annotated, Dict, Any
-from datetime import datetime
+from typing import Annotated
 
 from cli.internal.utility.config import read_config
 from cli.internal.aws.session import create_session

--- a/cli/commands/backup.py
+++ b/cli/commands/backup.py
@@ -9,7 +9,7 @@ from cli.internal.utility.config import read_config
 from cli.internal.aws.session import create_session
 from cli.internal.aws.client import get_client
 from cli.internal.aws.resource_filtering import list_resource_by_tag
-from cli.internal.aws.snapshotting import initiate_snapshot, check_snapshot_status
+from cli.internal.aws.backup import backup_rds_resources
 
 POLL_INTERVAL = 30 #seconds
 
@@ -54,45 +54,3 @@ def backup(
         case _:
             typer.echo(f"Provider {provider} is not supported yet.")
             raise typer.Exit(code=1)
-
-def backup_rds_resources(resources: list[dict[str, any]], session: boto3.Session, region: str, parallel: int):
-    """Backup RDS resources with parallel execution and polling."""
-    available_clusters = [
-        resource for resource in resources if resource["Status"] == "available"
-    ]
-    
-    if not available_clusters:
-        typer.echo("No available Aurora clusters found to backup")
-        return
-
-    typer.echo(f"Starting backup for {len(available_clusters)} Aurora cluster(s)")
-    
-    in_progress = []
-    pending = list(available_clusters)
-
-    while pending or in_progress:
-        while len(in_progress) < parallel and pending:
-            resource = pending.pop(0)
-            snapshot_result = initiate_snapshot(resource, session, region)
-            in_progress.append({
-                                'cluster': resource['DBClusterIdentifier'],
-                                'snapshot_id': snapshot_result['DBClusterSnapshotIdentifier'],
-                                'snapshot_arn': snapshot_result['DBClusterSnapshotArn'],
-                                'started': time.time()
-            })
-            typer.echo(f"Started backup: {snapshot_result['DBClusterSnapshotIdentifier']}")
-                            
-                        # Poll for completion
-            if in_progress:
-                time.sleep(POLL_INTERVAL)
-                            
-                completed = []
-                for backup in in_progress:
-                    status = check_snapshot_status(backup['snapshot_id'], session, region)
-                    if status in ["available", "failed"]:
-                        duration = time.time() - backup['started']
-                        typer.echo(f"Backup {backup['snapshot_id']}: {status} (took {duration:.0f}s)")
-                        completed.append(backup)
-                                    
-                    for backup in completed:
-                        in_progress.remove(backup)

--- a/cli/commands/backup.py
+++ b/cli/commands/backup.py
@@ -38,7 +38,7 @@ def backup(
                 match resource_type:
                     case "rds":
                         result = initiate_snapshot(resource, session, region)
-                        return result
+                        typer.echo(f"Result: {result}")
         case _:
             typer.echo(f"Provider {provider} is not supported yet.")
             raise typer.Exit(code=1)

--- a/cli/commands/backup.py
+++ b/cli/commands/backup.py
@@ -8,6 +8,7 @@ from cli.internal.utility.config import read_config
 from cli.internal.aws.session import create_session
 from cli.internal.aws.client import get_client
 from cli.internal.aws.resource_filtering import list_resource_by_tag
+from cli.internal.aws.snapshotting import initiate_snapshot, check_snapshot_status
 
 POLL_INTERVAL = 30 #seconds
 
@@ -81,74 +82,3 @@ def backup(
         case _:
             typer.echo(f"Provider {provider} is not supported yet.")
             raise typer.Exit(code=1)
-
-def initiate_snapshot(resource: dict[str, any], session: boto3.Session, region: None = "us-east-1") -> str:
-    snapshot_results = []
-    resource_id = resource['DBClusterIdentifier']
-    prefix = "backup"
-                        
-    try:
-        snapshot_result = create_cluster_snapshot(resource_id, prefix, session, region)
-        snapshot_results.append({
-            "cluster_id": resource_id,
-            "snapshot_id": snapshot_result["DBClusterSnapshotIdentifier"],
-            "status": "initiated",
-            "snapshot_arn": snapshot_result["DBClusterSnapshotArn"]
-        })
-                            
-        typer.echo(f"Successfully initiated snapshot for cluster: {resource_id}")
-    except Exception as e:
-        snapshot_results.append({
-            'cluster_id': resource_id,
-            'status': 'failed',
-            'error': str(e)
-        })
-        typer.echo(f"Failed to create snapshot for cluster {resource_id}: {str(e)}")
-
-def check_snapshot_status(snapshot_id: str, session: boto3.Session, region: str) -> str:
-    """Check the current status of a snapshot."""
-    client = get_client("rds", session, region)
-    response = client.describe_db_cluster_snapshots(
-        DBClusterSnapshotIdentifier=snapshot_id
-    )
-    return response['DBClusterSnapshots'][0]['Status']
-
-def create_cluster_snapshot(cluster_id: str, prefix: str, session: boto3.Session, region: str) -> Dict[str, Any]:
-    timestamp = datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
-    snapshot_id = f"{prefix}-{cluster_id}-{timestamp}"
-    
-    try:
-        client = get_client("rds", session, region)
-        
-        response = client.create_db_cluster_snapshot(
-            DBClusterSnapshotIdentifier=snapshot_id,
-            DBClusterIdentifier=cluster_id,
-            Tags=[
-                {
-                    "Key": "resource",
-                    "Value": f"{cluster_id}"
-                },
-                {
-                    "Key": "createdAt",
-                    "Value": timestamp
-                },
-                {
-                    "Key": "prefix",
-                    "Value": prefix
-                },
-                {
-                    "Key": "version",
-                    "Value": "0.1.0"
-                },
-                {
-                    "Key": "origin",
-                    "Value": "snapctl"
-                }
-            ]
-        )
-        
-        return response['DBClusterSnapshot']
-        
-    except Exception as e:
-        typer.echo(f"Error creating snapshot for {cluster_id}: {str(e)}")
-        raise

--- a/cli/commands/main.py
+++ b/cli/commands/main.py
@@ -1,9 +1,11 @@
 import typer
-from cli.commands.plan import app as plan_app
+from cli.commands.plan import app as plan_command
+from cli.commands.backup import app as backup_command
 
 app = typer.Typer()
 
-app.add_typer(plan_app)
+app.add_typer(plan_command)
+app.add_typer(backup_command)
 
 if __name__ == "__main__":
     app()

--- a/cli/commands/plan.py
+++ b/cli/commands/plan.py
@@ -4,6 +4,7 @@ from typing_extensions import Annotated
 from cli.internal.utility.config import read_config
 from cli.internal.aws.plan import aws_plan
 from cli.internal.aws.session import create_session_with_profile, create_session_with_role
+
 app = typer.Typer()
 
 @app.command()

--- a/cli/commands/plan.py
+++ b/cli/commands/plan.py
@@ -3,7 +3,7 @@ from typing_extensions import Annotated
 
 from cli.internal.utility.config import read_config
 from cli.internal.aws.plan import aws_plan
-from cli.internal.aws.session import create_session_with_profile, create_session_with_role
+from cli.internal.aws.session import create_session
 
 app = typer.Typer()
 
@@ -17,13 +17,7 @@ def plan(
     provider = config["provider"]["name"]
     
     auth = config["auth"]
-    session = None
-    if "role_arn" in auth:
-        session = create_session_with_role(auth)
-    elif "profile" in auth:
-        session = create_session_with_profile(auth)
-    else:
-        raise ValueError("No valid authentication method found in config")
+    session = create_session(auth)
     
     match provider:
         case "aws":

--- a/cli/internal/aws/backup.py
+++ b/cli/internal/aws/backup.py
@@ -1,0 +1,48 @@
+import typer
+import boto3
+import time
+from .snapshotting import initiate_snapshot, check_snapshot_status
+
+POLL_INTERVAL = 30 #seconds
+
+def backup_rds_resources(resources: list[dict[str, any]], session: boto3.Session, region: str, parallel: int):
+    """Backup RDS resources with parallel execution and polling."""
+    available_clusters = [
+        resource for resource in resources if resource["Status"] == "available"
+    ]
+    
+    if not available_clusters:
+        typer.echo("No available Aurora clusters found to backup")
+        return
+
+    typer.echo(f"Starting backup for {len(available_clusters)} Aurora cluster(s)")
+    
+    in_progress = []
+    pending = list(available_clusters)
+
+    while pending or in_progress:
+        while len(in_progress) < parallel and pending:
+            resource = pending.pop(0)
+            snapshot_result = initiate_snapshot(resource, session, region)
+            in_progress.append({
+                                'cluster': resource['DBClusterIdentifier'],
+                                'snapshot_id': snapshot_result['DBClusterSnapshotIdentifier'],
+                                'snapshot_arn': snapshot_result['DBClusterSnapshotArn'],
+                                'started': time.time()
+            })
+            typer.echo(f"Started backup: {snapshot_result['DBClusterSnapshotIdentifier']}")
+                            
+                        # Poll for completion
+            if in_progress:
+                time.sleep(POLL_INTERVAL)
+                            
+                completed = []
+                for backup in in_progress:
+                    status = check_snapshot_status(backup['snapshot_id'], session, region)
+                    if status in ["available", "failed"]:
+                        duration = time.time() - backup['started']
+                        typer.echo(f"Backup {backup['snapshot_id']}: {status} (took {duration:.0f}s)")
+                        completed.append(backup)
+                                    
+                    for backup in completed:
+                        in_progress.remove(backup)

--- a/cli/internal/aws/formatter.py
+++ b/cli/internal/aws/formatter.py
@@ -3,7 +3,6 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.tree import Tree
 from rich import box
-import re
 
 def format_rds_cluster(config: dict, instances: list[dict[str, Any]]):
     """Format RDS cluster data for terminal display with only important info"""

--- a/cli/internal/aws/formatter.py
+++ b/cli/internal/aws/formatter.py
@@ -5,56 +5,10 @@ from rich.tree import Tree
 from rich import box
 import re
 
-def format_scheduling_config(config:dict):
-    schedule = config["protect"]["schedule"]
-    retention = config["protect"]["retention"]
-    
-    # Parse schedule
-    schedule_match = re.match(r'^(daily|weekly|monthly)@(\d+)(am|pm)$', schedule, re.IGNORECASE)
-    if not schedule_match:
-        raise ValueError('Invalid schedule format')
-    
-    frequency, hour, period = schedule_match.groups()
-    hour = int(hour)
-    
-    # Convert to 24-hour format
-    if period.lower() == 'pm' and hour != 12:
-        hour_24 = hour + 12
-    elif period.lower() == 'am' and hour == 12:
-        hour_24 = 0
-    else:
-        hour_24 = hour
-    
-    schedule_text = f"{frequency.capitalize()} backups at {hour_24}:00 UTC"
-    
-    # Parse retention
-    retention_match = re.match(r'^(\d+)([dwmy])$', retention)
-    if not retention_match:
-        raise ValueError('Invalid retention format')
-    
-    amount, unit = retention_match.groups()
-    amount = int(amount)
-    
-    unit_map = {
-        'd': 'day',
-        'w': 'week',
-        'm': 'month',
-        'y': 'year'
-    }
-    
-    unit_name = unit_map[unit] + ('s' if amount > 1 else '')
-    retention_text = f"Retain for {amount} {unit_name}"
-    
-    return {
-        'schedule': schedule_text,
-        'retention': retention_text
-    }
-
 def format_rds_cluster(config: dict, instances: list[dict[str, Any]]):
     """Format RDS cluster data for terminal display with only important info"""
     app_name = config["app"]
     region = config["provider"]["region"]
-    scheduling_text = format_scheduling_config(config)
     resource_name = config["protect"]["resources"][0]["name"]
     tags = config["protect"]["resources"][0]["discover"]
     auth = config["auth"]
@@ -85,12 +39,6 @@ def format_rds_cluster(config: dict, instances: list[dict[str, Any]]):
         )
         console.print(header)
         console.print()
-
-    # Schedule & Retention
-    console.print("[bold]📋 Schedule & Retention[/bold]")
-    console.print(f"   [dim]•[/dim] {scheduling_text["schedule"]}")
-    console.print(f"   [dim]•[/dim] {scheduling_text["retention"]}")
-    console.print()
 
     # Resources Tree
     console.print("[bold]🗄️  Resources to Backup[/bold]")

--- a/cli/internal/aws/session.py
+++ b/cli/internal/aws/session.py
@@ -30,6 +30,17 @@ def create_session_with_role(auth_config: dict) -> boto3.Session:
         aws_session_token=credentials['SessionToken']
     )
 
-def create_session_with_profile(auth_config):
+def create_session_with_profile(auth_config) -> boto3.Session:
     """Create session with a named profile"""
     return boto3.Session(profile_name=auth_config["profile"])
+
+def create_session(auth_config) -> boto3.Session:
+    session = None
+    if "role_arn" in auth_config:
+        session = create_session_with_role(auth_config)
+    elif "profile" in auth_config:
+        session = create_session_with_profile(auth_config)
+    else:
+        raise ValueError("No valid authentication method found in config")
+    
+    return session

--- a/cli/internal/aws/snapshotting.py
+++ b/cli/internal/aws/snapshotting.py
@@ -1,0 +1,76 @@
+from typing import Dict, Any
+import typer
+import boto3 
+from datetime import datetime
+from .client import get_client
+
+def initiate_snapshot(resource: dict[str, any], session: boto3.Session, region: None = "us-east-1") -> str:
+    snapshot_results = []
+    resource_id = resource['DBClusterIdentifier']
+    prefix = "backup"
+                        
+    try:
+        snapshot_result = create_cluster_snapshot(resource_id, prefix, session, region)
+        snapshot_results.append({
+            "cluster_id": resource_id,
+            "snapshot_id": snapshot_result["DBClusterSnapshotIdentifier"],
+            "status": "initiated",
+            "snapshot_arn": snapshot_result["DBClusterSnapshotArn"]
+        })
+                            
+        typer.echo(f"Successfully initiated snapshot for cluster: {resource_id}")
+    except Exception as e:
+        snapshot_results.append({
+            'cluster_id': resource_id,
+            'status': 'failed',
+            'error': str(e)
+        })
+        typer.echo(f"Failed to create snapshot for cluster {resource_id}: {str(e)}")
+
+def check_snapshot_status(snapshot_id: str, session: boto3.Session, region: str) -> str:
+    """Check the current status of a snapshot."""
+    client = get_client("rds", session, region)
+    response = client.describe_db_cluster_snapshots(
+        DBClusterSnapshotIdentifier=snapshot_id
+    )
+    return response['DBClusterSnapshots'][0]['Status']
+
+def create_cluster_snapshot(cluster_id: str, prefix: str, session: boto3.Session, region: str) -> Dict[str, Any]:
+    timestamp = datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
+    snapshot_id = f"{prefix}-{cluster_id}-{timestamp}"
+    
+    try:
+        client = get_client("rds", session, region)
+        
+        response = client.create_db_cluster_snapshot(
+            DBClusterSnapshotIdentifier=snapshot_id,
+            DBClusterIdentifier=cluster_id,
+            Tags=[
+                {
+                    "Key": "resource",
+                    "Value": f"{cluster_id}"
+                },
+                {
+                    "Key": "createdAt",
+                    "Value": timestamp
+                },
+                {
+                    "Key": "prefix",
+                    "Value": prefix
+                },
+                {
+                    "Key": "version",
+                    "Value": "0.1.0"
+                },
+                {
+                    "Key": "origin",
+                    "Value": "snapctl"
+                }
+            ]
+        )
+        
+        return response['DBClusterSnapshot']
+        
+    except Exception as e:
+        typer.echo(f"Error creating snapshot for {cluster_id}: {str(e)}")
+        raise


### PR DESCRIPTION
### Summary
I'm adding the `backup` command which allows users to specify the resources they need to be backed up. `Backup` command finds all the resources that are tagged in the config and then initiates backups in parallel. In this case, it only backs up RDS instances and adds tags:

Added tags:
```bash
{
   "Key": "resource",
   "Value": f"{cluster_id}"
},
{
   "Key": "createdAt",
   "Value": timestamp
},
{
   "Key": "prefix",
   "Value": prefix
},
{
    "Key": "version",
    "Value": "0.1.0"
},
{
    "Key": "origin",
     "Value": "snapctl"
}
```

It also creates back ups with this format: `{prefix}-{cluster_id}-{timestamp}`

**TODO**:
- [x] Idempotency check: does the backup already exist? is the cluster/db in available state?
- [x] Set an amount of parallel back ups that can happen at any one time.

Note: I'm intentionally leaving out the ability for the command to add tags similar to the actual source resource because I don't know how useful it will be for the MVP.