### PR TITLE
Update `protect` to `backup`

### DIFF
--- a/cli/commands/backup.py
+++ b/cli/commands/backup.py
@@ -25,7 +25,7 @@ def backup(
     
     match provider:
         case "aws":
-            for resource_config in config["protect"]["resources"]:
+            for resource_config in config["backup"]["resources"]:
                 service_type = resource_config["type"]
                 resource_name = resource_config["name"]
                 tags = resource_config["tags"]

--- a/cli/internal/aws/formatter.py
+++ b/cli/internal/aws/formatter.py
@@ -8,8 +8,8 @@ def format_rds_cluster(config: dict, instances: list[dict[str, Any]]):
     """Format RDS cluster data for terminal display with only important info"""
     app_name = config["app"]
     region = config["provider"]["region"]
-    resource_name = config["protect"]["resources"][0]["name"]
-    tags = config["protect"]["resources"][0]["discover"]
+    resource_name = config["backup"]["resources"][0]["name"]
+    tags = config["backup"]["resources"][0]["discover"]
     auth = config["auth"]
     
     console = Console()

--- a/cli/internal/aws/plan.py
+++ b/cli/internal/aws/plan.py
@@ -4,9 +4,9 @@ from .formatter import format_rds_cluster
 from .resource_filtering import list_resource_by_tag
 
 def aws_plan(config: dict, session: boto3.Session):
-    service = config["protect"]["resources"][0]["type"]
+    service = config["backup"]["resources"][0]["type"]
     region = config["provider"]["region"]
-    tags = config["protect"]["resources"][0]["discover"]
+    tags = config["backup"]["resources"][0]["discover"]
     
     client = get_client(service, session, region)
     


### PR DESCRIPTION
Because it is more natural when a user uses the commands. That is when someone runs `snapctl backup` it makes sense that the config file reflects that using:
```bash
**backup**:
    resources:
    - type: rds
       name: production-databases
       discover: "tag:Unit=critical"
```
instead of:
```bash
**protect**:
    resources:
    - type: rds
       name: production-databases
       discover: "tag:Unit=critical"
```